### PR TITLE
paramaterize bed centers and offsets based on postion_max values in printer.cfg

### DIFF
--- a/vibration_data/vibration_macro.cfg
+++ b/vibration_data/vibration_macro.cfg
@@ -11,11 +11,11 @@ gcode:
 gcode:
 		G28
 		#X Vibration - With Input Shaper
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-input-shaper.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-input-shaper.csv
@@ -31,21 +31,21 @@ gcode:
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-input-shaper.csv
 
 		#B Vibration - With Input Shaper
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-input-shaper.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-input-shaper.csv
 		
 		#A Vibration - With Input Shaper
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-input-shaper.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-input-shaper.csv
@@ -53,11 +53,11 @@ gcode:
 		SET_INPUT_SHAPER SHAPER_FREQ_X=0 SHAPER_FREQ_Y=0
 		
 		#X Vibration - Stock
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-stock.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-stock.csv
@@ -73,21 +73,21 @@ gcode:
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-stock.csv
 
 		#B Vibration - Stock
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-stock.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-stock.csv
 		
 		#A Vibration - Stock
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-stock.csv
-		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-stock.csv

--- a/vibration_data/vibration_macro.cfg
+++ b/vibration_data/vibration_macro.cfg
@@ -1,51 +1,63 @@
 [gcode_macro resonance_test]
 gcode:
+		# Set variables for axis centers
+		{% set midx = printer.configfile.config.stepper_x.position_max|float / 2 %}
+		{% set midy = printer.configfile.config.stepper_y.position_max|float / 2 %}
+
 		G28
-		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 AXIS=X FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-x.csv
-		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 AXIS=Y FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-y.csv
-		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 VIB_X=1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-b.csv
-		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 VIB_X=-1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-a.csv
+		TEST_VIBRATIONS X={ midx } Y={ midy } Z=20 AXIS=X FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-x.csv
+		TEST_VIBRATIONS X={ midx } Y={ midy } Z=20 AXIS=Y FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-y.csv
+		TEST_VIBRATIONS X={ midx } Y={ midy } Z=20 VIB_X=1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-b.csv
+		TEST_VIBRATIONS X={ midx } Y={ midy } Z=20 VIB_X=-1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-a.csv
 
 
 [gcode_macro vibration_test]
 gcode:
+		# Set variables for axis centers
+		{% set midx = printer.configfile.config.stepper_x.position_max|float / 2 %}
+		{% set midy = printer.configfile.config.stepper_y.position_max|float / 2 %}
+
+		# Store the user's intial input_shaper frequency parameters
+		{% set initShapeX = printer.configfile.config.input_shaper.shaper_freq_x %}
+		{% set initShapeY = printer.configfile.config.input_shaper.shaper_freq_y %}
+
 		G28
 		#X Vibration - With Input Shaper
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
+		G1 X{ midx - 25 } Y{ midy } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-input-shaper.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
+		G1 X{ midx + 25 } Y{ midy } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-input-shaper.csv
 
 		#Y Vibration - With Input Shaper
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx } Y{ midy  - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-y-input-shaper.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-input-shaper.csv
 
 		#B Vibration - With Input Shaper
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx - 25 } Y{ midy - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-input-shaper.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx + 25 } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-input-shaper.csv
 		
 		#A Vibration - With Input Shaper
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx + 25 } Y{ midy - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-input-shaper.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx - 25 } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-input-shaper.csv
@@ -53,41 +65,44 @@ gcode:
 		SET_INPUT_SHAPER SHAPER_FREQ_X=0 SHAPER_FREQ_Y=0
 		
 		#X Vibration - Stock
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
+		G1 X{ midx - 25 } Y{ midy } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-stock.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
+		G1 X{ midx + 25 } Y{ midy } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-stock.csv
 
 		#Y Vibration - Stock
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx } Y{ midy - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-y-stock.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-stock.csv
 
 		#B Vibration - Stock
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx - 25 } Y{ midy - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-stock.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx + 25 } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-stock.csv
 		
 		#A Vibration - Stock
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
+		G1 X{ midx + 25 } Y{ midy - 25 } Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-stock.csv
-		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
+		G1 X{ midx - 25 } Y{ midy + 25 } F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-stock.csv
+
+		# Restore user's input shaper frequency parameters
+		SET_INPUT_SHAPER SHAPER_FREQ_X={ initShapeX } SHAPER_FREQ_Y={ initShapeY }

--- a/vibration_data/vibration_macro.cfg
+++ b/vibration_data/vibration_macro.cfg
@@ -1,51 +1,51 @@
 [gcode_macro resonance_test]
 gcode:
 		G28
-		TEST_VIBRATIONS X=125 Y=125 Z=20 AXIS=X FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-x.csv
-		TEST_VIBRATIONS X=125 Y=125 Z=20 AXIS=Y FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-y.csv
-		TEST_VIBRATIONS X=125 Y=125 Z=20 VIB_X=1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-b.csv
-		TEST_VIBRATIONS X=125 Y=125 Z=20 VIB_X=-1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-a.csv
+		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 AXIS=X FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-x.csv
+		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 AXIS=Y FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-y.csv
+		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 VIB_X=1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-b.csv
+		TEST_VIBRATIONS X={ printer.configfile.config.stepper_x.position_max|float / 2 } Y={ printer.configfile.config.stepper_Y.position_max|float / 2 } Z=20 VIB_X=-1 VIB_Y=1  FREQ_START=10 FREQ_END=100 FREQ_STEP=0.5 OUTPUT=/tmp/vib-a.csv
 
 
 [gcode_macro vibration_test]
 gcode:
 		G28
 		#X Vibration - With Input Shaper
-		G1 X100 Y125 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-input-shaper.csv
-		G1 X150 Y125 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-input-shaper.csv
 
 		#Y Vibration - With Input Shaper
-		G1 X125 Y100 Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-y-input-shaper.csv
-		G1 X125 Y150 F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-input-shaper.csv
 
 		#B Vibration - With Input Shaper
-		G1 X100 Y100 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-input-shaper.csv
-		G1 X150 Y150 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-input-shaper.csv
 		
 		#A Vibration - With Input Shaper
-		G1 X150 Y100 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-input-shaper.csv
-		G1 X100 Y150 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-input-shaper.csv
@@ -53,41 +53,41 @@ gcode:
 		SET_INPUT_SHAPER SHAPER_FREQ_X=0 SHAPER_FREQ_Y=0
 		
 		#X Vibration - Stock
-		G1 X100 Y125 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-x-stock.csv
-		G1 X150 Y125 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-x-stock.csv
 
 		#Y Vibration - Stock
-		G1 X125 Y100 Z20
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-y-stock.csv
-		G1 X125 Y150 F6000
+		G1 X{ printer.configfile.config.stepper_x.position_max|float / 2} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-y-stock.csv
 
 		#B Vibration - Stock
-		G1 X100 Y100 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-b-stock.csv
-		G1 X150 Y150 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-b-stock.csv
 		
 		#A Vibration - Stock
-		G1 X150 Y100 Z20
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 + 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 - 25} Z20
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=3200 OUTPUT=/tmp/accel-a-stock.csv
-		G1 X100 Y150 F6000
+		G1 Y{ printer.configfile.config.stepper_x.position_max|float / 2 - 25} Y{ printer.configfile.config.stepper_y.position_max|float / 2 + 25} F6000
 		M400
 		G4 P300
 		ACCELEROMETER_MEASURE CHIP=rpiaccel RATE=0 OUTPUT=/tmp/accel-a-stock.csv


### PR DESCRIPTION
All positions are now calculated based on `position_max` values in the config sections `stepper_x` and `stepper_y` in `printer.cfg`. The expressions are rather long and ugly, but seem functional when tested in smaller macros. I could not squeeze them into gcode variables that were much shorter so did not bother.
NB: I have not tested the full macros yet, but should have time in the coming days. Please give them a shot if you get a chance and let me know